### PR TITLE
Fikset feilen med siste syv dager spørringen som ikke fungerer

### DIFF
--- a/src/main/kotlin/no/nav/klage/search/api/mapper/KlagebehandlingerSearchCriteriaMapper.kt
+++ b/src/main/kotlin/no/nav/klage/search/api/mapper/KlagebehandlingerSearchCriteriaMapper.kt
@@ -51,7 +51,7 @@ class KlagebehandlingerSearchCriteriaMapper {
             KlagebehandlingerSearchCriteria.SortField.FRIST
         },
         ferdigstiltFom = getFerdigstiltFom(queryParams),
-        statuskategori = if (queryParams.ferdigstiltFom != null) {
+        statuskategori = if (queryParams.ferdigstiltFom != null || queryParams.ferdigstiltDaysAgo != null) {
             KlagebehandlingerSearchCriteria.Statuskategori.AVSLUTTET
         } else {
             KlagebehandlingerSearchCriteria.Statuskategori.AAPEN


### PR DESCRIPTION
Vi hadde innført en ny parameter `ferdigstiltDaysAgo`, som bare ble brukt for å regne ut ferdigstiltFom, ikke for å sette statuskategori. Resultatet av det var at vi endte opp med en ES-spørring som både krevde at avsluttetAvSaksbehandler ikke var satt:
```
"must_not" : [
      {
        "exists" : {
          "field" : "avsluttetAvSaksbehandler",
          "boost" : 1.0
        }
      }
    ]
```
og som krevde at avsluttettAvSaksbehandler var innen en spesifikk range:
```
     {
        "range" : {
          "avsluttetAvSaksbehandler" : {
            "from" : "2021-12-07",
            "to" : null,
            "include_lower" : true,
            "include_upper" : true,
            "time_zone" : "Z",
            "format" : "yyyy-MM-dd",
            "boost" : 1.0
          }
        }
      }
```
Og da er det ikke lett å få så mange treff..