### PR TITLE
Bytter fra Elasticsearch til OpenSearch. 

### DIFF
--- a/src/main/kotlin/no/nav/klage/search/config/ElasticsearchServiceConfiguration.kt
+++ b/src/main/kotlin/no/nav/klage/search/config/ElasticsearchServiceConfiguration.kt
@@ -1,6 +1,5 @@
 package no.nav.klage.search.config
 
-import no.finn.unleash.Unleash
 import no.nav.klage.search.repositories.EsKlagebehandlingRepository
 import no.nav.klage.search.service.ElasticsearchService
 import org.apache.http.HttpHost
@@ -19,9 +18,9 @@ import org.springframework.context.event.ContextStoppedEvent
 
 @Configuration
 class ElasticsearchServiceConfiguration(
-    @Value("\${ELASTIC_USERNAME}") private val username: String,
-    @Value("\${ELASTIC_PASSWORD}") private val password: String,
-    @Value("\${ELASTIC_URI}") private val uri: String,
+    @Value("\${OPEN_SEARCH_USERNAME}") private val username: String,
+    @Value("\${OPEN_SEARCH_PASSWORD}") private val password: String,
+    @Value("\${OPEN_SEARCH_URI}") private val uri: String,
 ) :
     ApplicationListener<ContextStoppedEvent> {
 
@@ -49,13 +48,8 @@ class ElasticsearchServiceConfiguration(
     }
 
     @Bean
-    fun elasticsearchService(
-        unleash: Unleash
-    ): ElasticsearchService {
-        return ElasticsearchService(
-            esKlagebehandlingRepository(),
-            unleash
-        )
+    fun elasticsearchService(): ElasticsearchService {
+        return ElasticsearchService(esKlagebehandlingRepository())
     }
 
 

--- a/src/main/kotlin/no/nav/klage/search/service/ElasticsearchService.kt
+++ b/src/main/kotlin/no/nav/klage/search/service/ElasticsearchService.kt
@@ -1,6 +1,5 @@
 package no.nav.klage.search.service
 
-import no.finn.unleash.Unleash
 import no.nav.klage.kodeverk.MedunderskriverFlyt
 import no.nav.klage.kodeverk.Type
 import no.nav.klage.search.domain.KlagebehandlingerSearchCriteria
@@ -36,7 +35,6 @@ import java.util.concurrent.TimeUnit
 
 open class ElasticsearchService(
     private val esKlagebehandlingRepository: EsKlagebehandlingRepository,
-    private val unleash: Unleash
 ) :
     ApplicationListener<ContextRefreshedEvent> {
 
@@ -49,32 +47,24 @@ open class ElasticsearchService(
     }
 
     fun recreateIndex() {
-        if (unleash.isEnabled("klage.indexFromSearch", false)) {
-            esKlagebehandlingRepository.recreateIndex()
-        }
+        esKlagebehandlingRepository.recreateIndex()
     }
 
     override fun onApplicationEvent(event: ContextRefreshedEvent) {
         try {
             esKlagebehandlingRepository.createIndex()
         } catch (e: Exception) {
-            logger.error("Unable to initialize Elasticsearch", e)
+            logger.error("Unable to initialize OpenSearch", e)
         }
     }
 
     fun save(klagebehandlinger: List<EsKlagebehandling>) {
-        if (unleash.isEnabled("klage.indexFromSearch", false)) {
-            esKlagebehandlingRepository.save(klagebehandlinger)
-        }
+        esKlagebehandlingRepository.save(klagebehandlinger)
     }
 
     fun save(klagebehandling: EsKlagebehandling) {
-        if (unleash.isEnabled("klage.indexFromSearch", false)) {
-            logger.debug("Skal indeksere fra kabal-search, klage med id ${klagebehandling.id}")
-            esKlagebehandlingRepository.save(klagebehandling)
-        } else {
-            logger.debug("Skal ikke indeksere fra kabal-search")
-        }
+        logger.debug("Skal indeksere fra kabal-search, klage med id ${klagebehandling.id}")
+        esKlagebehandlingRepository.save(klagebehandling)
     }
 
     open fun findByCriteria(criteria: KlagebehandlingerSearchCriteria): KlagebehandlingerSearchHits {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,9 +15,9 @@ AXSYS_APIKEY: 357
 nais:
   cluster:
     name: local
-ELASTIC_USERNAME: elasticsearch
-ELASTIC_PASSWORD: password
-ELASTIC_URI: "http://localhost:9200"
+OPEN_SEARCH_USERNAME: whatever
+OPEN_SEARCH_PASSWORD: password
+OPEN_SEARCH_URI: "http://localhost:9200"
 
 AXSYS_URL: https://axsys.dev.adeo.no/v1
 

--- a/src/test/kotlin/no/nav/klage/search/service/CreateIndexFromEsKlagebehandlingTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/CreateIndexFromEsKlagebehandlingTest.kt
@@ -27,7 +27,7 @@ class CreateIndexFromEsKlagebehandlingTest {
     companion object {
         @Container
         @JvmField
-        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+        val esContainer: TestOpenSearchContainer = TestOpenSearchContainer.instance
     }
 
     @MockkBean(relaxed = true)

--- a/src/test/kotlin/no/nav/klage/search/service/EktefelleElasticsearchServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/EktefelleElasticsearchServiceTest.kt
@@ -33,7 +33,7 @@ class EktefelleElasticsearchServiceTest {
     companion object {
         @Container
         @JvmField
-        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+        val esContainer: TestOpenSearchContainer = TestOpenSearchContainer.instance
     }
 
     @MockkBean(relaxed = true)

--- a/src/test/kotlin/no/nav/klage/search/service/ElasticsearchIndexingTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/ElasticsearchIndexingTest.kt
@@ -34,7 +34,7 @@ class ElasticsearchIndexingTest {
     companion object {
         @Container
         @JvmField
-        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+        val esContainer: TestOpenSearchContainer = TestOpenSearchContainer.instance
     }
 
     @MockkBean(relaxed = true)

--- a/src/test/kotlin/no/nav/klage/search/service/ElasticsearchServiceFindSaksbehandlereTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/ElasticsearchServiceFindSaksbehandlereTest.kt
@@ -34,7 +34,7 @@ class ElasticsearchServiceFindSaksbehandlereTest {
     companion object {
         @Container
         @JvmField
-        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+        val esContainer: TestOpenSearchContainer = TestOpenSearchContainer.instance
     }
 
     @MockkBean(relaxed = true)

--- a/src/test/kotlin/no/nav/klage/search/service/ElasticsearchServiceStatusTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/ElasticsearchServiceStatusTest.kt
@@ -35,7 +35,7 @@ class ElasticsearchServiceStatusTest {
     companion object {
         @Container
         @JvmField
-        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+        val esContainer: TestOpenSearchContainer = TestOpenSearchContainer.instance
     }
 
     @MockkBean(relaxed = true)

--- a/src/test/kotlin/no/nav/klage/search/service/ElasticsearchServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/ElasticsearchServiceTest.kt
@@ -34,7 +34,7 @@ class ElasticsearchServiceTest {
     companion object {
         @Container
         @JvmField
-        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+        val esContainer: TestOpenSearchContainer = TestOpenSearchContainer.instance
     }
 
     @MockkBean(relaxed = true)

--- a/src/test/kotlin/no/nav/klage/search/service/FortroligElasticsearchServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/FortroligElasticsearchServiceTest.kt
@@ -35,7 +35,7 @@ class FortroligElasticsearchServiceTest {
     companion object {
         @Container
         @JvmField
-        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+        val esContainer: TestOpenSearchContainer = TestOpenSearchContainer.instance
     }
 
     @MockkBean(relaxed = true)

--- a/src/test/kotlin/no/nav/klage/search/service/RelatedKlagebehandlingerTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/RelatedKlagebehandlingerTest.kt
@@ -35,7 +35,7 @@ class RelatedKlagebehandlingerTest {
     companion object {
         @Container
         @JvmField
-        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+        val esContainer: TestOpenSearchContainer = TestOpenSearchContainer.instance
     }
 
     @MockkBean(relaxed = true)

--- a/src/test/kotlin/no/nav/klage/search/service/StatistikkInElasticsearchServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/StatistikkInElasticsearchServiceTest.kt
@@ -35,7 +35,7 @@ class StatistikkInElasticsearchServiceTest {
     companion object {
         @Container
         @JvmField
-        val esContainer: TestElasticsearchContainer = TestElasticsearchContainer.instance
+        val esContainer: TestOpenSearchContainer = TestOpenSearchContainer.instance
     }
 
     @MockkBean(relaxed = true)

--- a/src/test/kotlin/no/nav/klage/search/service/TestOpenSearchContainer.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/TestOpenSearchContainer.kt
@@ -1,0 +1,51 @@
+package no.nav.klage.search.service
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
+import java.time.Duration
+
+
+class TestOpenSearchContainer private constructor() :
+    GenericContainer<TestOpenSearchContainer>(IMAGE_VERSION) {
+
+    companion object {
+        private const val IMAGE_VERSION = "opensearchproject/opensearch:1.1.0"
+
+        private val CONTAINER: TestOpenSearchContainer = TestOpenSearchContainer()
+
+        val network = Network.newNetwork()
+
+        val instance: TestOpenSearchContainer
+            get() {
+                return CONTAINER
+            }
+    }
+
+    override fun start() {
+        withNetwork(network)
+        addExposedPort(9200)
+        setWaitStrategy(
+            HttpWaitStrategy()
+                .forPort(9200)
+                .forStatusCodeMatching { response: Int -> response == 200 || response == 401 }
+                .withStartupTimeout(Duration.ofMinutes(2)))
+        withEnv("discovery.type", "single-node")
+        withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
+        withEnv("DISABLE_SECURITY_PLUGIN", "true")
+
+        super.start()
+        System.setProperty("OPEN_SEARCH_USERNAME", "whatever")
+        System.setProperty("OPEN_SEARCH_PASSWORD", "changeme")
+        System.setProperty(
+            "OPEN_SEARCH_URI", "http://${CONTAINER.host}:${CONTAINER.firstMappedPort}"
+        )
+    }
+
+    override fun stop() {
+        //CONTAINER.stop()
+        //do nothing, JVM handles shut down
+    }
+
+
+}


### PR DESCRIPTION
Litt rydding vil gjenstå i etterkant, både mtp navngiving og at vi kan bytte over til OpenSearch sitt egen klient-bibliotek. (Jeg bruker nå siste versjon av ES sitt som er kompatibelt med OS.) Det jeg har gjort her er "minst mulig endringer" for å kunne bruke OS.