### PR TITLE
Refaktorert de siste metodene

### DIFF
--- a/src/main/kotlin/no/nav/klage/search/api/controller/KlagebehandlingSearchController.kt
+++ b/src/main/kotlin/no/nav/klage/search/api/controller/KlagebehandlingSearchController.kt
@@ -42,10 +42,12 @@ class KlagebehandlingSearchController(
     )
     @PostMapping("/personogoppgaver", produces = ["application/json"])
     fun getPersonOgOppgaver(@RequestBody input: SearchPersonByFnrInput): FnrSearchResponse {
+        val saksbehandler = oAuthTokenService.getInnloggetIdent()
+
         val personSearchResponse: PersonSearchResponse =
             personSearchService.fnrSearch(klagebehandlingerSearchCriteriaMapper.toOppgaverOmPersonSearchCriteria(input))
                 ?: throw PersonNotFoundException("Person med fnr ${input.query} ikke funnet")
-        val saksbehandler = oAuthTokenService.getInnloggetIdent()
+
         return klagebehandlingListMapper.mapPersonSearchResponseToFnrSearchResponse(
             personSearchResponse = personSearchResponse,
             saksbehandler = saksbehandler,

--- a/src/main/kotlin/no/nav/klage/search/api/controller/KlagebehandlingSearchController.kt
+++ b/src/main/kotlin/no/nav/klage/search/api/controller/KlagebehandlingSearchController.kt
@@ -43,7 +43,7 @@ class KlagebehandlingSearchController(
     @PostMapping("/personogoppgaver", produces = ["application/json"])
     fun getPersonOgOppgaver(@RequestBody input: SearchPersonByFnrInput): FnrSearchResponse {
         val personSearchResponse: PersonSearchResponse =
-            personSearchService.fnrSearch(klagebehandlingerSearchCriteriaMapper.toSearchCriteria(input))
+            personSearchService.fnrSearch(klagebehandlingerSearchCriteriaMapper.toOppgaverOmPersonSearchCriteria(input))
                 ?: throw PersonNotFoundException("Person med fnr ${input.query} ikke funnet")
         val saksbehandler = oAuthTokenService.getInnloggetIdent()
         return klagebehandlingListMapper.mapPersonSearchResponseToFnrSearchResponse(

--- a/src/main/kotlin/no/nav/klage/search/api/controller/OppgaverListController.kt
+++ b/src/main/kotlin/no/nav/klage/search/api/controller/OppgaverListController.kt
@@ -131,18 +131,18 @@ class OppgaverListController(
         )
 
         //val hjemler: List<String> = lovligeValgteHjemler(queryParams = queryParams, ytelser = ytelser)
-        val searchCriteria = klagebehandlingerSearchCriteriaMapper.toSearchCriteria(
+        val searchCriteria = klagebehandlingerSearchCriteriaMapper.toSaksbehandlersUferdigeOppgaverSearchCriteria(
             navIdent = navIdent,
             queryParams = queryParams.copy(ytelser = ytelser) //, hjemler = hjemler),
         )
 
-        val esResponse = elasticsearchService.findByCriteria(searchCriteria)
+        val esResponse = elasticsearchService.findSaksbehandlersUferdigeOppgaverByCriteria(searchCriteria)
         return KlagebehandlingerListRespons(
             antallTreffTotalt = esResponse.totalHits.toInt(),
             klagebehandlinger = klagebehandlingListMapper.mapEsKlagebehandlingerToListView(
                 esKlagebehandlinger = esResponse.searchHits.map { it.content },
                 visePersonData = true,
-                saksbehandlere = searchCriteria.saksbehandlere,
+                saksbehandlere = listOf(searchCriteria.saksbehandler),
                 tilgangTilYtelser = getAlleYtelserInnloggetSaksbehandlerKanBehandle()
             )
         )
@@ -164,12 +164,12 @@ class OppgaverListController(
         val valgtEnhet = getEnhetOrThrowException(enhetId)
         val ytelser = lovligeValgteYtelser(queryParams = queryParams, valgteEnheter = listOf(valgtEnhet))
         //val hjemler: List<String> = lovligeValgteHjemler(queryParams = queryParams, ytelser = ytelser)
-        val searchCriteria = klagebehandlingerSearchCriteriaMapper.toSearchCriteria(
+        val searchCriteria = klagebehandlingerSearchCriteriaMapper.toEnhetensFerdigstilteOppgaverSearchCriteria(
             enhetId = enhetId,
             queryParams = queryParams.copy(ytelser = ytelser) //, hjemler = hjemler),
         )
 
-        val esResponse = elasticsearchService.findByCriteria(searchCriteria)
+        val esResponse = elasticsearchService.findEnhetensFerdigstilteOppgaverByCriteria(searchCriteria)
         return KlagebehandlingerListRespons(
             antallTreffTotalt = esResponse.totalHits.toInt(),
             klagebehandlinger = klagebehandlingListMapper.mapEsKlagebehandlingerToListView(
@@ -202,12 +202,12 @@ class OppgaverListController(
         }
 
         //val hjemler: List<String> = lovligeValgteHjemler(queryParams = queryParams, ytelser = ytelser)
-        val searchCriteria = klagebehandlingerSearchCriteriaMapper.toSearchCriteria(
+        val searchCriteria = klagebehandlingerSearchCriteriaMapper.toEnhetensUferdigeOppgaverSearchCriteria(
             enhetId = enhetId,
             queryParams = queryParams.copy(ytelser = ytelser) //, hjemler = hjemler),
         )
 
-        val esResponse = elasticsearchService.findByCriteria(searchCriteria)
+        val esResponse = elasticsearchService.findEnhetensUferdigeOppgaverByCriteria(searchCriteria)
         return KlagebehandlingerListRespons(
             antallTreffTotalt = esResponse.totalHits.toInt(),
             klagebehandlinger = klagebehandlingListMapper.mapEsKlagebehandlingerToListView(
@@ -243,7 +243,7 @@ class OppgaverListController(
         }
         //val hjemler: List<String> = lovligeValgteHjemler(queryParams = queryParams, ytelser = ytelser)
         return AntallUtgaatteFristerResponse(
-            antall = elasticsearchService.countByCriteria(
+            antall = elasticsearchService.countLedigeOppgaverMedUtgaatFristByCriteria(
                 criteria = klagebehandlingerSearchCriteriaMapper.toSearchCriteriaForLedigeMedUtgaattFrist(
                     navIdent = navIdent,
                     queryParams = queryParams.copy(ytelser = ytelser) //, hjemler = hjemler),

--- a/src/main/kotlin/no/nav/klage/search/api/mapper/KlagebehandlingerSearchCriteriaMapper.kt
+++ b/src/main/kotlin/no/nav/klage/search/api/mapper/KlagebehandlingerSearchCriteriaMapper.kt
@@ -160,16 +160,7 @@ class KlagebehandlingerSearchCriteriaMapper(
                 Order.ASC
             }
         }
-
-    //TODO: Skulle denne vært brukt??
-    private fun mapFerdigstiltFom(queryParams: KlagebehandlingerQueryParams): LocalDate? {
-        return if (queryParams.ferdigstiltDaysAgo != null) {
-            LocalDate.now().minusDays(queryParams.ferdigstiltDaysAgo.toLong())
-        } else {
-            queryParams.ferdigstiltFom
-        }
-    }
-
+    
     private fun mapFerdigstiltFom(queryParams: FerdigstilteOppgaverQueryParams): LocalDate =
         LocalDate.now().minusDays(queryParams.ferdigstiltDaysAgo)
 

--- a/src/main/kotlin/no/nav/klage/search/api/mapper/KlagebehandlingerSearchCriteriaMapper.kt
+++ b/src/main/kotlin/no/nav/klage/search/api/mapper/KlagebehandlingerSearchCriteriaMapper.kt
@@ -5,7 +5,6 @@ import no.nav.klage.kodeverk.Ytelse
 import no.nav.klage.kodeverk.hjemmel.Hjemmel
 import no.nav.klage.search.api.view.*
 import no.nav.klage.search.domain.*
-import no.nav.klage.search.domain.saksbehandler.Enhet
 import no.nav.klage.search.service.saksbehandler.OAuthTokenService
 import no.nav.klage.search.util.getLogger
 import org.springframework.stereotype.Service
@@ -25,15 +24,17 @@ class KlagebehandlingerSearchCriteriaMapper(
     fun kanBehandleFortrolig() = oAuthTokenService.kanBehandleFortrolig()
     fun kanBehandleStrengtFortrolig() = oAuthTokenService.kanBehandleStrengtFortrolig()
 
-    fun toSearchCriteria(input: SearchPersonByFnrInput) = KlagebehandlingerSearchCriteria(
-        foedselsnr = input.query,
-        statuskategori = Statuskategori.ALLE,
+    fun toOppgaverOmPersonSearchCriteria(input: SearchPersonByFnrInput) = OppgaverOmPersonSearchCriteria(
+        fnr = input.query,
         offset = 0,
+        //TODO: Hvorfor setter vi denne? Hvorfor bare vise de to første??
         limit = 2,
         kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
         kanBehandleFortrolig = kanBehandleFortrolig(),
         kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
     )
+
+    //-- saksbehandlers oppgaver:
 
     fun toSaksbehandlersFerdigstilteOppgaverSearchCriteria(
         navIdent: String,
@@ -53,82 +54,89 @@ class KlagebehandlingerSearchCriteriaMapper(
         kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
     )
 
-    fun toSearchCriteria(
+    fun toSaksbehandlersUferdigeOppgaverSearchCriteria(
         navIdent: String,
         queryParams: MineUferdigeOppgaverQueryParams,
-    ) = KlagebehandlingerSearchCriteria(
-        enhetId = null,
+    ) = SaksbehandlersUferdigeOppgaverSearchCriteria(
         typer = queryParams.typer.map { Type.of(it) },
         ytelser = queryParams.ytelser.map { Ytelse.of(it) },
         hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
+        saksbehandler = navIdent,
+        sortField = mapSortField(queryParams.sortering),
         order = mapOrder(queryParams.rekkefoelge, queryParams.sortering),
         offset = queryParams.start,
         limit = queryParams.antall,
-        erTildeltSaksbehandler = true,
-        saksbehandlere = listOf(navIdent),
-        sortField = mapSortField(queryParams.sortering),
-        ferdigstiltFom = null,
-        statuskategori = Statuskategori.AAPEN,
         kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
         kanBehandleFortrolig = kanBehandleFortrolig(),
         kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
     )
+
+    //-- enhetens oppgaver:
+
+    fun toEnhetensFerdigstilteOppgaverSearchCriteria(
+        enhetId: String,
+        queryParams: EnhetensFerdigstilteOppgaverQueryParams,
+    ) = EnhetensFerdigstilteOppgaverSearchCriteria(
+        typer = queryParams.typer.map { Type.of(it) },
+        ytelser = queryParams.ytelser.map { Ytelse.of(it) },
+        hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
+        enhetId = enhetId,
+        saksbehandlere = queryParams.tildelteSaksbehandlere,
+        ferdigstiltFom = mapFerdigstiltFom(queryParams),
+        sortField = mapSortField(queryParams.sortering),
+        order = mapOrder(queryParams.rekkefoelge, queryParams.sortering),
+        offset = queryParams.start,
+        limit = queryParams.antall,
+        kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
+        kanBehandleFortrolig = kanBehandleFortrolig(),
+        kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
+    )
+
+    fun toEnhetensUferdigeOppgaverSearchCriteria(
+        enhetId: String,
+        queryParams: EnhetensUferdigeOppgaverQueryParams,
+    ) = EnhetensUferdigeOppgaverSearchCriteria(
+        typer = queryParams.typer.map { Type.of(it) },
+        ytelser = queryParams.ytelser.map { Ytelse.of(it) },
+        hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
+        enhetId = enhetId,
+        saksbehandlere = queryParams.tildelteSaksbehandlere,
+        sortField = mapSortField(queryParams.sortering),
+        order = mapOrder(queryParams.rekkefoelge, queryParams.sortering),
+        offset = queryParams.start,
+        limit = queryParams.antall,
+        kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
+        kanBehandleFortrolig = kanBehandleFortrolig(),
+        kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
+    )
+
+    //-- ledige oppgaver:
 
     fun toLedigeOppgaverSearchCriteria(queryParams: MineLedigeOppgaverQueryParams): LedigeOppgaverSearchCriteria =
         LedigeOppgaverSearchCriteria(
             typer = queryParams.typer.map { Type.of(it) },
             ytelser = queryParams.ytelser.map { Ytelse.of(it) },
             hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
+            sortField = mapSortField(queryParams.sortering),
             order = mapOrder(queryParams.rekkefoelge, queryParams.sortering),
             offset = queryParams.start,
             limit = queryParams.antall,
-            sortField = mapSortField(queryParams.sortering),
             kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
             kanBehandleFortrolig = kanBehandleFortrolig(),
             kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
         )
 
-    fun toSearchCriteria(
-        enhetId: String,
-        queryParams: EnhetensUferdigeOppgaverQueryParams,
-    ) = KlagebehandlingerSearchCriteria(
-        enhetId = enhetId,
-        typer = queryParams.typer.map { Type.of(it) },
-        ytelser = queryParams.ytelser.map { Ytelse.of(it) },
-        hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
-        order = mapOrder(queryParams.rekkefoelge, queryParams.sortering),
-        offset = queryParams.start,
-        limit = queryParams.antall,
-        erTildeltSaksbehandler = true,
-        saksbehandlere = queryParams.tildelteSaksbehandlere,
-        sortField = mapSortField(queryParams.sortering),
-        ferdigstiltFom = null,
-        statuskategori = Statuskategori.AAPEN,
-        kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
-        kanBehandleFortrolig = kanBehandleFortrolig(),
-        kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
-    )
-
-    fun toSearchCriteria(
-        enhetId: String,
-        queryParams: EnhetensFerdigstilteOppgaverQueryParams,
-    ) = KlagebehandlingerSearchCriteria(
-        enhetId = enhetId,
-        typer = queryParams.typer.map { Type.of(it) },
-        ytelser = queryParams.ytelser.map { Ytelse.of(it) },
-        hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
-        order = mapOrder(queryParams.rekkefoelge, queryParams.sortering),
-        offset = queryParams.start,
-        limit = queryParams.antall,
-        erTildeltSaksbehandler = true,
-        saksbehandlere = queryParams.tildelteSaksbehandlere,
-        sortField = mapSortField(queryParams.sortering),
-        ferdigstiltFom = mapFerdigstiltFom(queryParams),
-        statuskategori = Statuskategori.AVSLUTTET,
-        kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
-        kanBehandleFortrolig = kanBehandleFortrolig(),
-        kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
-    )
+    fun toSearchCriteriaForLedigeMedUtgaattFrist(navIdent: String, queryParams: MineLedigeOppgaverQueryParams) =
+        CountLedigeOppgaverMedUtgaattFristSearchCriteria(
+            typer = queryParams.typer.map { Type.of(it) },
+            ytelser = queryParams.ytelser.map { Ytelse.of(it) },
+            hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
+            fristFom = LocalDate.now().minusYears(15),
+            fristTom = LocalDate.now().minusDays(1),
+            kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
+            kanBehandleFortrolig = kanBehandleFortrolig(),
+            kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
+        )
 
     private fun mapSortField(sortering: Sortering?): SortField =
         when (sortering) {
@@ -153,41 +161,7 @@ class KlagebehandlingerSearchCriteriaMapper(
             }
         }
 
-    fun toSearchCriteria(
-        navIdent: String,
-        queryParams: KlagebehandlingerQueryParams,
-        enhet: Enhet
-    ) = KlagebehandlingerSearchCriteria(
-        enhetId = if (queryParams.erTildeltSaksbehandler == true && queryParams.tildeltSaksbehandler.isEmpty()) enhet.enhetId else null,
-        typer = queryParams.typer.map { Type.of(it) },
-        ytelser = queryParams.ytelser.map { Ytelse.of(it) },
-        hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
-        order = if (queryParams.rekkefoelge == Rekkefoelge.SYNKENDE) {
-            Order.DESC
-        } else {
-            Order.ASC
-        },
-        offset = queryParams.start,
-        limit = queryParams.antall,
-        erTildeltSaksbehandler = queryParams.erTildeltSaksbehandler,
-        saksbehandlere = queryParams.tildeltSaksbehandler,
-        //projection = queryParams.projeksjon?.let { KlagebehandlingerSearchCriteria.Projection.valueOf(it.name) },
-        sortField = if (queryParams.sortering == Sortering.MOTTATT) {
-            SortField.MOTTATT
-        } else {
-            SortField.FRIST
-        },
-        ferdigstiltFom = mapFerdigstiltFom(queryParams),
-        statuskategori = if (queryParams.ferdigstiltFom != null || queryParams.ferdigstiltDaysAgo != null) {
-            Statuskategori.AVSLUTTET
-        } else {
-            Statuskategori.AAPEN
-        },
-        kanBehandleEgenAnsatt = oAuthTokenService.kanBehandleEgenAnsatt(),
-        kanBehandleFortrolig = oAuthTokenService.kanBehandleFortrolig(),
-        kanBehandleStrengtFortrolig = oAuthTokenService.kanBehandleStrengtFortrolig(),
-    )
-
+    //TODO: Skulle denne vært brukt??
     private fun mapFerdigstiltFom(queryParams: KlagebehandlingerQueryParams): LocalDate? {
         return if (queryParams.ferdigstiltDaysAgo != null) {
             LocalDate.now().minusDays(queryParams.ferdigstiltDaysAgo.toLong())
@@ -198,45 +172,6 @@ class KlagebehandlingerSearchCriteriaMapper(
 
     private fun mapFerdigstiltFom(queryParams: FerdigstilteOppgaverQueryParams): LocalDate =
         LocalDate.now().minusDays(queryParams.ferdigstiltDaysAgo)
-
-
-    fun toSearchCriteriaForLedigeMedUtgaattFrist(navIdent: String, queryParams: MineLedigeOppgaverQueryParams) =
-        KlagebehandlingerSearchCriteria(
-            enhetId = null,
-            typer = queryParams.typer.map { Type.of(it) },
-            ytelser = queryParams.ytelser.map { Ytelse.of(it) },
-            hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
-            erTildeltSaksbehandler = false,
-            saksbehandlere = emptyList(),
-            ferdigstiltFom = null,
-            statuskategori = Statuskategori.AAPEN,
-            fristFom = LocalDate.now().minusYears(15),
-            fristTom = LocalDate.now().minusDays(1),
-            offset = 0,
-            limit = 1,
-            kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
-            kanBehandleFortrolig = kanBehandleFortrolig(),
-            kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
-        )
-
-    fun toFristUtgaattIkkeTildeltSearchCriteria(navIdent: String, queryParams: KlagebehandlingerQueryParams) =
-        KlagebehandlingerSearchCriteria(
-            enhetId = null,
-            typer = queryParams.typer.map { Type.of(it) },
-            ytelser = queryParams.ytelser.map { Ytelse.of(it) },
-            hjemler = queryParams.hjemler.map { Hjemmel.of(it) },
-            erTildeltSaksbehandler = false,
-            saksbehandlere = emptyList(),
-            ferdigstiltFom = null,
-            statuskategori = Statuskategori.AAPEN,
-            fristFom = LocalDate.now().minusYears(15),
-            fristTom = LocalDate.now().minusDays(1),
-            offset = 0,
-            limit = 1,
-            kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
-            kanBehandleFortrolig = kanBehandleFortrolig(),
-            kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
-        )
 
 }
 

--- a/src/main/kotlin/no/nav/klage/search/api/mapper/KlagebehandlingerSearchCriteriaMapper.kt
+++ b/src/main/kotlin/no/nav/klage/search/api/mapper/KlagebehandlingerSearchCriteriaMapper.kt
@@ -27,8 +27,7 @@ class KlagebehandlingerSearchCriteriaMapper(
     fun toOppgaverOmPersonSearchCriteria(input: SearchPersonByFnrInput) = OppgaverOmPersonSearchCriteria(
         fnr = input.query,
         offset = 0,
-        //TODO: Hvorfor setter vi denne? Hvorfor bare vise de to første??
-        limit = 2,
+        limit = 100,
         kanBehandleEgenAnsatt = kanBehandleEgenAnsatt(),
         kanBehandleFortrolig = kanBehandleFortrolig(),
         kanBehandleStrengtFortrolig = kanBehandleStrengtFortrolig(),
@@ -160,7 +159,7 @@ class KlagebehandlingerSearchCriteriaMapper(
                 Order.ASC
             }
         }
-    
+
     private fun mapFerdigstiltFom(queryParams: FerdigstilteOppgaverQueryParams): LocalDate =
         LocalDate.now().minusDays(queryParams.ferdigstiltDaysAgo)
 

--- a/src/main/kotlin/no/nav/klage/search/domain/KlagebehandlingerSearchCriteria.kt
+++ b/src/main/kotlin/no/nav/klage/search/domain/KlagebehandlingerSearchCriteria.kt
@@ -4,8 +4,8 @@ import no.nav.klage.kodeverk.Type
 import no.nav.klage.kodeverk.Ytelse
 import no.nav.klage.kodeverk.hjemmel.Hjemmel
 import java.time.LocalDate
-import java.time.LocalDateTime
 
+/*
 data class KlagebehandlingerSearchCriteria(
     override val typer: List<Type> = emptyList(),
     override val ytelser: List<Ytelse> = emptyList(),
@@ -33,8 +33,9 @@ data class KlagebehandlingerSearchCriteria(
     override val kanBehandleFortrolig: Boolean,
     override val kanBehandleStrengtFortrolig: Boolean,
 ) : BasicSearchCriteria, PageableSearchCriteria, SortableSearchCriteria, SecuritySearchCriteria
+*/
 
-data class ExtraPersonWithYtelser(val foedselsnr: String, val ytelser: List<Ytelse>)
+//data class ExtraPersonWithYtelser(val foedselsnr: String, val ytelser: List<Ytelse>)
 
 enum class SortField {
     FRIST, MOTTATT
@@ -48,7 +49,7 @@ enum class Statuskategori {
     AAPEN, AVSLUTTET, ALLE
 }
 
-fun KlagebehandlingerSearchCriteria.isFnrSoek() = raw.isNumeric()
+//fun KlagebehandlingerSearchCriteria.isFnrSoek() = raw.isNumeric()
 
 private fun String.isNumeric() = toLongOrNull() != null
 
@@ -74,6 +75,17 @@ interface SecuritySearchCriteria {
     val kanBehandleStrengtFortrolig: Boolean
 }
 
+data class OppgaverOmPersonSearchCriteria(
+    val fnr: String,
+
+    override val offset: Int,
+    override val limit: Int,
+
+    override val kanBehandleEgenAnsatt: Boolean,
+    override val kanBehandleFortrolig: Boolean,
+    override val kanBehandleStrengtFortrolig: Boolean,
+) : PageableSearchCriteria, SecuritySearchCriteria
+
 data class SaksbehandlersFerdigstilteOppgaverSearchCriteria(
     override val typer: List<Type>,
     override val ytelser: List<Ytelse>,
@@ -81,6 +93,60 @@ data class SaksbehandlersFerdigstilteOppgaverSearchCriteria(
 
     val saksbehandler: String,
     val ferdigstiltFom: LocalDate,
+
+    override val sortField: SortField,
+    override val order: Order,
+    override val offset: Int,
+    override val limit: Int,
+
+    override val kanBehandleEgenAnsatt: Boolean,
+    override val kanBehandleFortrolig: Boolean,
+    override val kanBehandleStrengtFortrolig: Boolean,
+) : BasicSearchCriteria, PageableSearchCriteria, SortableSearchCriteria, SecuritySearchCriteria
+
+data class SaksbehandlersUferdigeOppgaverSearchCriteria(
+    override val typer: List<Type>,
+    override val ytelser: List<Ytelse>,
+    override val hjemler: List<Hjemmel>,
+
+    val saksbehandler: String,
+
+    override val sortField: SortField,
+    override val order: Order,
+    override val offset: Int,
+    override val limit: Int,
+
+    override val kanBehandleEgenAnsatt: Boolean,
+    override val kanBehandleFortrolig: Boolean,
+    override val kanBehandleStrengtFortrolig: Boolean,
+) : BasicSearchCriteria, PageableSearchCriteria, SortableSearchCriteria, SecuritySearchCriteria
+
+data class EnhetensFerdigstilteOppgaverSearchCriteria(
+    override val typer: List<Type>,
+    override val ytelser: List<Ytelse>,
+    override val hjemler: List<Hjemmel>,
+
+    val enhetId: String,
+    val saksbehandlere: List<String>,
+    val ferdigstiltFom: LocalDate,
+
+    override val sortField: SortField,
+    override val order: Order,
+    override val offset: Int,
+    override val limit: Int,
+
+    override val kanBehandleEgenAnsatt: Boolean,
+    override val kanBehandleFortrolig: Boolean,
+    override val kanBehandleStrengtFortrolig: Boolean,
+) : BasicSearchCriteria, PageableSearchCriteria, SortableSearchCriteria, SecuritySearchCriteria
+
+data class EnhetensUferdigeOppgaverSearchCriteria(
+    override val typer: List<Type>,
+    override val ytelser: List<Ytelse>,
+    override val hjemler: List<Hjemmel>,
+
+    val enhetId: String,
+    val saksbehandlere: List<String>,
 
     override val sortField: SortField,
     override val order: Order,
@@ -106,3 +172,16 @@ data class LedigeOppgaverSearchCriteria(
     override val kanBehandleFortrolig: Boolean,
     override val kanBehandleStrengtFortrolig: Boolean,
 ) : BasicSearchCriteria, PageableSearchCriteria, SortableSearchCriteria, SecuritySearchCriteria
+
+data class CountLedigeOppgaverMedUtgaattFristSearchCriteria(
+    override val typer: List<Type>,
+    override val ytelser: List<Ytelse>,
+    override val hjemler: List<Hjemmel>,
+
+    val fristFom: LocalDate,
+    val fristTom: LocalDate,
+
+    override val kanBehandleEgenAnsatt: Boolean,
+    override val kanBehandleFortrolig: Boolean,
+    override val kanBehandleStrengtFortrolig: Boolean,
+) : BasicSearchCriteria, SecuritySearchCriteria

--- a/src/main/kotlin/no/nav/klage/search/domain/KlagebehandlingerSearchCriteria.kt
+++ b/src/main/kotlin/no/nav/klage/search/domain/KlagebehandlingerSearchCriteria.kt
@@ -45,13 +45,13 @@ enum class Order {
     ASC, DESC
 }
 
-enum class Statuskategori {
-    AAPEN, AVSLUTTET, ALLE
-}
+//enum class Statuskategori {
+//    AAPEN, AVSLUTTET, ALLE
+//}
 
 //fun KlagebehandlingerSearchCriteria.isFnrSoek() = raw.isNumeric()
 
-private fun String.isNumeric() = toLongOrNull() != null
+//private fun String.isNumeric() = toLongOrNull() != null
 
 interface PageableSearchCriteria {
     val offset: Int

--- a/src/main/kotlin/no/nav/klage/search/service/ElasticsearchService.kt
+++ b/src/main/kotlin/no/nav/klage/search/service/ElasticsearchService.kt
@@ -1,7 +1,6 @@
 package no.nav.klage.search.service
 
 import no.nav.klage.kodeverk.MedunderskriverFlyt
-import no.nav.klage.kodeverk.Type
 import no.nav.klage.search.domain.*
 import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling.Status.*
@@ -17,6 +16,7 @@ import org.opensearch.common.unit.TimeValue
 import org.opensearch.index.query.BoolQueryBuilder
 import org.opensearch.index.query.QueryBuilder
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.index.query.TermQueryBuilder
 import org.opensearch.search.aggregations.AggregationBuilder
 import org.opensearch.search.aggregations.AggregationBuilders
 import org.opensearch.search.aggregations.bucket.range.ParsedDateRange
@@ -64,6 +64,17 @@ open class ElasticsearchService(private val esKlagebehandlingRepository: EsKlage
         esKlagebehandlingRepository.save(klagebehandling)
     }
 
+    open fun findOppgaverOmPersonByCriteria(criteria: OppgaverOmPersonSearchCriteria): KlagebehandlingerSearchHits {
+        val searchSourceBuilder = SearchSourceBuilder()
+        searchSourceBuilder.query(criteria.toEsQuery())
+        searchSourceBuilder.addPaging(criteria)
+        searchSourceBuilder.timeout(TimeValue(60, TimeUnit.SECONDS))
+
+        val searchHits = esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
+        logger.debug("ANTALL TREFF: ${searchHits.totalHits}")
+        return searchHits
+    }
+
     open fun findLedigeOppgaverByCriteria(criteria: LedigeOppgaverSearchCriteria): KlagebehandlingerSearchHits {
         val searchSourceBuilder = SearchSourceBuilder()
         searchSourceBuilder.query(criteria.toEsQuery())
@@ -71,8 +82,7 @@ open class ElasticsearchService(private val esKlagebehandlingRepository: EsKlage
         searchSourceBuilder.addSorting(criteria)
         searchSourceBuilder.timeout(TimeValue(60, TimeUnit.SECONDS))
 
-        val searchHits =
-            esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
+        val searchHits = esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
         logger.debug("ANTALL TREFF: ${searchHits.totalHits}")
         return searchHits
     }
@@ -84,12 +94,48 @@ open class ElasticsearchService(private val esKlagebehandlingRepository: EsKlage
         searchSourceBuilder.addSorting(criteria)
         searchSourceBuilder.timeout(TimeValue(60, TimeUnit.SECONDS))
 
-        val searchHits =
-            esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
+        val searchHits = esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
         logger.debug("ANTALL TREFF: ${searchHits.totalHits}")
         return searchHits
     }
 
+    open fun findSaksbehandlersUferdigeOppgaverByCriteria(criteria: SaksbehandlersUferdigeOppgaverSearchCriteria): KlagebehandlingerSearchHits {
+        val searchSourceBuilder = SearchSourceBuilder()
+        searchSourceBuilder.query(criteria.toEsQuery())
+        searchSourceBuilder.addPaging(criteria)
+        searchSourceBuilder.addSorting(criteria)
+        searchSourceBuilder.timeout(TimeValue(60, TimeUnit.SECONDS))
+
+        val searchHits = esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
+        logger.debug("ANTALL TREFF: ${searchHits.totalHits}")
+        return searchHits
+    }
+
+    open fun findEnhetensFerdigstilteOppgaverByCriteria(criteria: EnhetensFerdigstilteOppgaverSearchCriteria): KlagebehandlingerSearchHits {
+        val searchSourceBuilder = SearchSourceBuilder()
+        searchSourceBuilder.query(criteria.toEsQuery())
+        searchSourceBuilder.addPaging(criteria)
+        searchSourceBuilder.addSorting(criteria)
+        searchSourceBuilder.timeout(TimeValue(60, TimeUnit.SECONDS))
+
+        val searchHits = esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
+        logger.debug("ANTALL TREFF: ${searchHits.totalHits}")
+        return searchHits
+    }
+
+    open fun findEnhetensUferdigeOppgaverByCriteria(criteria: EnhetensUferdigeOppgaverSearchCriteria): KlagebehandlingerSearchHits {
+        val searchSourceBuilder = SearchSourceBuilder()
+        searchSourceBuilder.query(criteria.toEsQuery())
+        searchSourceBuilder.addPaging(criteria)
+        searchSourceBuilder.addSorting(criteria)
+        searchSourceBuilder.timeout(TimeValue(60, TimeUnit.SECONDS))
+
+        val searchHits = esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
+        logger.debug("ANTALL TREFF: ${searchHits.totalHits}")
+        return searchHits
+    }
+
+    /*
     open fun findByCriteria(criteria: KlagebehandlingerSearchCriteria): KlagebehandlingerSearchHits {
         val searchSourceBuilder = SearchSourceBuilder()
         searchSourceBuilder.query(criteria.toEsQuery())
@@ -97,11 +143,11 @@ open class ElasticsearchService(private val esKlagebehandlingRepository: EsKlage
         searchSourceBuilder.addSorting(criteria)
         searchSourceBuilder.timeout(TimeValue(60, TimeUnit.SECONDS))
 
-        val searchHits =
-            esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
+        val searchHits = esKlagebehandlingRepository.search(searchSourceBuilder, emptyList())
         logger.debug("ANTALL TREFF: ${searchHits.totalHits}")
         return searchHits
     }
+     */
 
     open fun findSaksbehandlereByEnhetCriteria(criteria: SaksbehandlereByEnhetSearchCriteria): SortedSet<Saksbehandler> {
         val searchHits: SearchHits<EsKlagebehandling> = esKlagebehandlingRepository.search(criteria.toEsQuery())
@@ -156,7 +202,7 @@ open class ElasticsearchService(private val esKlagebehandlingRepository: EsKlage
         return getMedian(saksdokumenterPerAvsluttetBehandling)
     }
 
-    open fun countByCriteria(criteria: KlagebehandlingerSearchCriteria): Int {
+    open fun countLedigeOppgaverMedUtgaatFristByCriteria(criteria: CountLedigeOppgaverMedUtgaattFristSearchCriteria): Int {
         return esKlagebehandlingRepository.count(criteria.toEsQuery()).toInt()
     }
 
@@ -185,6 +231,17 @@ open class ElasticsearchService(private val esKlagebehandlingRepository: EsKlage
         this.size(criteria.limit)
     }
 
+    private fun OppgaverOmPersonSearchCriteria.toEsQuery(): QueryBuilder {
+        logger.debug("Search criteria: {}", this)
+        val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
+        baseQuery.addSecurityFilters(this)
+
+        baseQuery.must(haveSakenGjelder(fnr))
+
+        logger.debug("Making search request with query {}", baseQuery.toString())
+        return baseQuery
+    }
+
     private fun SaksbehandlereByEnhetSearchCriteria.toEsQuery(): QueryBuilder {
         logger.debug("Search criteria: {}", this)
         val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
@@ -209,149 +266,70 @@ open class ElasticsearchService(private val esKlagebehandlingRepository: EsKlage
         return baseQuery
     }
 
+    private fun CountLedigeOppgaverMedUtgaattFristSearchCriteria.toEsQuery(): QueryBuilder {
+        logger.debug("Search criteria: {}", this)
+        val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
+        baseQuery.addSecurityFilters(this)
+        baseQuery.addBasicFilters(this)
+        baseQuery.mustNot(beAvsluttetAvSaksbehandler())
+        baseQuery.mustNot(beTildeltSaksbehandler())
+        baseQuery.must(haveFristMellom(fristFom, fristTom))
+        logger.debug("Making search request with query {}", baseQuery.toString())
+        return baseQuery
+    }
+
     private fun SaksbehandlersFerdigstilteOppgaverSearchCriteria.toEsQuery(): QueryBuilder {
         logger.debug("Search criteria: {}", this)
         val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
         baseQuery.addSecurityFilters(this)
         baseQuery.addBasicFilters(this)
-        baseQuery.must(beAvsluttetAvSaksbehandler())
-        baseQuery.must(beTildeltSaksbehandler(saksbehandler))
+        //baseQuery.must(beAvsluttetAvSaksbehandler())
         baseQuery.must(beAvsluttetAvSaksbehandlerEtter(ferdigstiltFom))
+        baseQuery.must(beTildeltSaksbehandler(saksbehandler))
 
         logger.debug("Making search request with query {}", baseQuery.toString())
         return baseQuery
     }
 
-    private fun KlagebehandlingerSearchCriteria.toEsQuery(): QueryBuilder {
-
-        val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
+    private fun SaksbehandlersUferdigeOppgaverSearchCriteria.toEsQuery(): QueryBuilder {
         logger.debug("Search criteria: {}", this)
-
+        val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
         baseQuery.addSecurityFilters(this)
+        baseQuery.addBasicFilters(this)
+        baseQuery.mustNot(beAvsluttetAvSaksbehandler())
+        baseQuery.must(beTildeltSaksbehandlerOrMedunderskriver(saksbehandler))
 
-        val combinedInnerFnrAndYtelseQuery = QueryBuilders.boolQuery()
-        baseQuery.must(combinedInnerFnrAndYtelseQuery)
+        logger.debug("Making search request with query {}", baseQuery.toString())
+        return baseQuery
+    }
 
-        val innerFnrAndYtelseQuery = QueryBuilders.boolQuery()
-        combinedInnerFnrAndYtelseQuery.should(innerFnrAndYtelseQuery)
-
-        val innerQueryFnr = QueryBuilders.boolQuery()
-        innerFnrAndYtelseQuery.must(innerQueryFnr)
-        foedselsnr?.let {
-            innerQueryFnr.should(QueryBuilders.termQuery("sakenGjelderFnr", it))
-        }
-
-        val innerQueryYtelse = QueryBuilders.boolQuery()
-        innerFnrAndYtelseQuery.must(innerQueryYtelse)
-        ytelser.forEach {
-            innerQueryYtelse.should(QueryBuilders.termQuery("ytelseId", it.id))
-        }
-
-        extraPersonWithYtelser?.let { extraPerson ->
-            val innerFnrAndYtelseEktefelleQuery = QueryBuilders.boolQuery()
-            combinedInnerFnrAndYtelseQuery.should(innerFnrAndYtelseEktefelleQuery)
-
-            innerFnrAndYtelseEktefelleQuery.must(
-                QueryBuilders.termQuery(
-                    "sakenGjelderFnr",
-                    extraPerson.foedselsnr
-                )
-            )
-
-            val innerYtelseEktefelleQuery = QueryBuilders.boolQuery()
-            innerFnrAndYtelseEktefelleQuery.must(innerYtelseEktefelleQuery)
-            extraPerson.ytelser.forEach { ytelse ->
-                innerYtelseEktefelleQuery.should(QueryBuilders.termQuery("ytelseId", ytelse.id))
-            }
-        }
-
-        when (statuskategori) {
-            Statuskategori.AAPEN -> baseQuery.mustNot(beAvsluttetAvSaksbehandler())
-            Statuskategori.AVSLUTTET -> baseQuery.must(beAvsluttetAvSaksbehandler())
-            Statuskategori.ALLE -> Unit
-        }
-
-        enhetId?.let {
-            baseQuery.must(QueryBuilders.termQuery("tildeltEnhet", enhetId))
-        }
-
-        val innerQueryBehandlingtype = QueryBuilders.boolQuery()
-        baseQuery.must(innerQueryBehandlingtype)
-        if (typer.isNotEmpty()) {
-            typer.forEach {
-                innerQueryBehandlingtype.should(QueryBuilders.termQuery("type", it.id))
-            }
-        } else {
-            innerQueryBehandlingtype.should(QueryBuilders.termQuery("type", Type.KLAGE.id))
-        }
-
-        erTildeltSaksbehandler?.let {
-            if (erTildeltSaksbehandler) {
-                baseQuery.must(beTildeltSaksbehandler())
-            } else {
-                baseQuery.mustNot(beTildeltSaksbehandler())
-            }
-        }
+    private fun EnhetensFerdigstilteOppgaverSearchCriteria.toEsQuery(): QueryBuilder {
+        logger.debug("Search criteria: {}", this)
+        val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
+        baseQuery.addSecurityFilters(this)
+        baseQuery.addBasicFilters(this)
+        //baseQuery.must(beAvsluttetAvSaksbehandler())
+        baseQuery.must(beAvsluttetAvSaksbehandlerEtter(ferdigstiltFom))
+        baseQuery.must(beTildeltEnhet(enhetId))
         if (saksbehandlere.isNotEmpty()) {
-            val innerQuerySaksbehandler = QueryBuilders.boolQuery()
-            saksbehandlere.forEach {
-                innerQuerySaksbehandler.should(QueryBuilders.termQuery("tildeltSaksbehandlerident", it))
-            }
-
-            if (statuskategori == Statuskategori.AAPEN) {
-                saksbehandlere.forEach {
-                    val innerMedunderskriverQuery = QueryBuilders.boolQuery()
-                    innerMedunderskriverQuery.must(QueryBuilders.termQuery("medunderskriverident", it))
-                    innerMedunderskriverQuery.must(
-                        QueryBuilders.termQuery(
-                            "medunderskriverFlyt",
-                            MedunderskriverFlyt.OVERSENDT_TIL_MEDUNDERSKRIVER.name
-                        )
-                    )
-                    innerQuerySaksbehandler.should(innerMedunderskriverQuery)
-                }
-            }
-
-            baseQuery.must(innerQuerySaksbehandler)
+            baseQuery.must(beTildeltSaksbehandler(saksbehandlere))
         }
 
-        opprettetFom?.let {
-            baseQuery.must(
-                QueryBuilders.rangeQuery("mottattKlageinstans").gte(it).format(ISO8601).timeZone(ZONEID_UTC)
-            )
-        }
-        opprettetTom?.let {
-            baseQuery.must(
-                QueryBuilders.rangeQuery("mottattKlageinstans").lte(it).format(ISO8601).timeZone(ZONEID_UTC)
-            )
-        }
-        ferdigstiltFom?.let {
-            baseQuery.must(
-                QueryBuilders.rangeQuery("avsluttetAvSaksbehandler").gte(it).format(ISO8601).timeZone(ZONEID_UTC)
-            )
-        }
-        ferdigstiltTom?.let {
-            baseQuery.must(
-                QueryBuilders.rangeQuery("avsluttetAvSaksbehandler").lte(it).format(ISO8601).timeZone(ZONEID_UTC)
-            )
-        }
-        fristFom?.let {
-            baseQuery.must(
-                QueryBuilders.rangeQuery("frist").gte(it).format(ISO8601).timeZone(ZONEID_UTC)
-            )
-        }
-        fristTom?.let {
-            baseQuery.must(
-                QueryBuilders.rangeQuery("frist").lte(it).format(ISO8601).timeZone(ZONEID_UTC)
-            )
-        }
+        logger.debug("Making search request with query {}", baseQuery.toString())
+        return baseQuery
+    }
 
-        if (hjemler.isNotEmpty()) {
-            val innerQueryHjemler = QueryBuilders.boolQuery()
-            baseQuery.must(innerQueryHjemler)
-            hjemler.forEach {
-                innerQueryHjemler.should(QueryBuilders.termQuery("hjemler", it.id))
-            }
+    private fun EnhetensUferdigeOppgaverSearchCriteria.toEsQuery(): QueryBuilder {
+        logger.debug("Search criteria: {}", this)
+        val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
+        baseQuery.addSecurityFilters(this)
+        baseQuery.addBasicFilters(this)
+        baseQuery.mustNot(beAvsluttetAvSaksbehandler())
+        baseQuery.must(beTildeltEnhet(enhetId))
+        if (saksbehandlere.isNotEmpty()) {
+            //TODO: Skal man her ta med oppgaver hvor en saksbehandler i enheten er medunderskriver på en annen enhets oppgave?
+            // Det er ikke med nå, jeg inkluderer ikke medunderskrivere i det hele tatt
+            baseQuery.must(beTildeltSaksbehandler(saksbehandlere))
         }
 
         logger.debug("Making search request with query {}", baseQuery.toString())
@@ -601,6 +579,15 @@ open class ElasticsearchService(private val esKlagebehandlingRepository: EsKlage
     private fun beAvsluttetAvSaksbehandlerEtter(ferdigstiltFom: LocalDate) =
         QueryBuilders.rangeQuery("avsluttetAvSaksbehandler").gte(ferdigstiltFom).format(ISO8601).timeZone(ZONEID_UTC)
 
+    private fun haveFristEtter(fristFom: LocalDate) =
+        QueryBuilders.rangeQuery("frist").gte(fristFom).format(ISO8601).timeZone(ZONEID_UTC)
+
+    private fun haveFristFoer(fristTom: LocalDate) =
+        QueryBuilders.rangeQuery("frist").lte(fristTom).format(ISO8601).timeZone(ZONEID_UTC)
+
+    private fun haveFristMellom(fristFom: LocalDate, fristTom: LocalDate) =
+        QueryBuilders.rangeQuery("frist").gte(fristFom).lte(fristTom).format(ISO8601).timeZone(ZONEID_UTC)
+
     private fun beTildeltSaksbehandler(saksbehandlere: List<String>): BoolQueryBuilder {
         val innerQuerySaksbehandler = QueryBuilders.boolQuery()
         saksbehandlere.forEach {
@@ -612,4 +599,169 @@ open class ElasticsearchService(private val esKlagebehandlingRepository: EsKlage
     private fun beTildeltSaksbehandler(navIdent: String) =
         QueryBuilders.termQuery("tildeltSaksbehandlerident", navIdent)
 
+    private fun beTildeltMedunderskriver(navIdent: String): BoolQueryBuilder {
+        val innerQueryMedunderskriver = QueryBuilders.boolQuery()
+        innerQueryMedunderskriver.must(QueryBuilders.termQuery("medunderskriverident", navIdent))
+        innerQueryMedunderskriver.must(
+            QueryBuilders.termQuery(
+                "medunderskriverFlyt",
+                MedunderskriverFlyt.OVERSENDT_TIL_MEDUNDERSKRIVER.name
+            )
+        )
+        return innerQueryMedunderskriver
+    }
+
+    private fun beTildeltSaksbehandlerOrMedunderskriver(navIdent: String): BoolQueryBuilder {
+        val innerQuery = QueryBuilders.boolQuery()
+        innerQuery.should(beTildeltSaksbehandler(navIdent))
+        innerQuery.should(beTildeltMedunderskriver(navIdent))
+        return innerQuery
+    }
+
+    private fun beTildeltEnhet(enhetId: String): TermQueryBuilder =
+        QueryBuilders.termQuery("tildeltEnhet", enhetId)
+
+    private fun haveSakenGjelder(fnr: String): TermQueryBuilder =
+        QueryBuilders.termQuery("sakenGjelderFnr", fnr)
+
+
+    //TODO: Har beholdt dette fordi det bare er her koden for relaterte personer og sånt er dokumentert.
+    /*
+   private fun KlagebehandlingerSearchCriteria.toEsQuery(): QueryBuilder {
+
+       val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
+       logger.debug("Search criteria: {}", this)
+
+       baseQuery.addSecurityFilters(this)
+
+       val combinedInnerFnrAndYtelseQuery = QueryBuilders.boolQuery()
+       baseQuery.must(combinedInnerFnrAndYtelseQuery)
+
+       val innerFnrAndYtelseQuery = QueryBuilders.boolQuery()
+       combinedInnerFnrAndYtelseQuery.should(innerFnrAndYtelseQuery)
+
+       val innerQueryFnr = QueryBuilders.boolQuery()
+       innerFnrAndYtelseQuery.must(innerQueryFnr)
+       foedselsnr?.let {
+           innerQueryFnr.should(QueryBuilders.termQuery("sakenGjelderFnr", it))
+       }
+
+       val innerQueryYtelse = QueryBuilders.boolQuery()
+       innerFnrAndYtelseQuery.must(innerQueryYtelse)
+       ytelser.forEach {
+           innerQueryYtelse.should(QueryBuilders.termQuery("ytelseId", it.id))
+       }
+
+       extraPersonWithYtelser?.let { extraPerson ->
+           val innerFnrAndYtelseEktefelleQuery = QueryBuilders.boolQuery()
+           combinedInnerFnrAndYtelseQuery.should(innerFnrAndYtelseEktefelleQuery)
+
+           innerFnrAndYtelseEktefelleQuery.must(
+               QueryBuilders.termQuery(
+                   "sakenGjelderFnr",
+                   extraPerson.foedselsnr
+               )
+           )
+
+           val innerYtelseEktefelleQuery = QueryBuilders.boolQuery()
+           innerFnrAndYtelseEktefelleQuery.must(innerYtelseEktefelleQuery)
+           extraPerson.ytelser.forEach { ytelse ->
+               innerYtelseEktefelleQuery.should(QueryBuilders.termQuery("ytelseId", ytelse.id))
+           }
+       }
+
+       when (statuskategori) {
+           Statuskategori.AAPEN -> baseQuery.mustNot(beAvsluttetAvSaksbehandler())
+           Statuskategori.AVSLUTTET -> baseQuery.must(beAvsluttetAvSaksbehandler())
+           Statuskategori.ALLE -> Unit
+       }
+
+       enhetId?.let {
+           baseQuery.must(QueryBuilders.termQuery("tildeltEnhet", enhetId))
+       }
+
+       val innerQueryBehandlingtype = QueryBuilders.boolQuery()
+       baseQuery.must(innerQueryBehandlingtype)
+       if (typer.isNotEmpty()) {
+           typer.forEach {
+               innerQueryBehandlingtype.should(QueryBuilders.termQuery("type", it.id))
+           }
+       } else {
+           innerQueryBehandlingtype.should(QueryBuilders.termQuery("type", Type.KLAGE.id))
+       }
+
+       erTildeltSaksbehandler?.let {
+           if (erTildeltSaksbehandler) {
+               baseQuery.must(beTildeltSaksbehandler())
+           } else {
+               baseQuery.mustNot(beTildeltSaksbehandler())
+           }
+       }
+       if (saksbehandlere.isNotEmpty()) {
+           val innerQuerySaksbehandler = QueryBuilders.boolQuery()
+           saksbehandlere.forEach {
+               innerQuerySaksbehandler.should(QueryBuilders.termQuery("tildeltSaksbehandlerident", it))
+           }
+
+           if (statuskategori == Statuskategori.AAPEN) {
+               saksbehandlere.forEach {
+                   val innerMedunderskriverQuery = QueryBuilders.boolQuery()
+                   innerMedunderskriverQuery.must(QueryBuilders.termQuery("medunderskriverident", it))
+                   innerMedunderskriverQuery.must(
+                       QueryBuilders.termQuery(
+                           "medunderskriverFlyt",
+                           MedunderskriverFlyt.OVERSENDT_TIL_MEDUNDERSKRIVER.name
+                       )
+                   )
+                   innerQuerySaksbehandler.should(innerMedunderskriverQuery)
+               }
+           }
+
+           baseQuery.must(innerQuerySaksbehandler)
+       }
+
+       opprettetFom?.let {
+           baseQuery.must(
+               QueryBuilders.rangeQuery("mottattKlageinstans").gte(it).format(ISO8601).timeZone(ZONEID_UTC)
+           )
+       }
+       opprettetTom?.let {
+           baseQuery.must(
+               QueryBuilders.rangeQuery("mottattKlageinstans").lte(it).format(ISO8601).timeZone(ZONEID_UTC)
+           )
+       }
+       ferdigstiltFom?.let {
+           baseQuery.must(
+               QueryBuilders.rangeQuery("avsluttetAvSaksbehandler").gte(it).format(ISO8601).timeZone(ZONEID_UTC)
+           )
+       }
+       ferdigstiltTom?.let {
+           baseQuery.must(
+               QueryBuilders.rangeQuery("avsluttetAvSaksbehandler").lte(it).format(ISO8601).timeZone(ZONEID_UTC)
+           )
+       }
+       fristFom?.let {
+           baseQuery.must(
+               QueryBuilders.rangeQuery("frist").gte(it).format(ISO8601).timeZone(ZONEID_UTC)
+           )
+       }
+       fristTom?.let {
+           baseQuery.must(
+               QueryBuilders.rangeQuery("frist").lte(it).format(ISO8601).timeZone(ZONEID_UTC)
+           )
+       }
+
+       if (hjemler.isNotEmpty()) {
+           val innerQueryHjemler = QueryBuilders.boolQuery()
+           baseQuery.must(innerQueryHjemler)
+           hjemler.forEach {
+               innerQueryHjemler.should(QueryBuilders.termQuery("hjemler", it.id))
+           }
+       }
+
+       logger.debug("Making search request with query {}", baseQuery.toString())
+       return baseQuery
+   }
+
+    */
 }

--- a/src/main/kotlin/no/nav/klage/search/service/PersonSearchService.kt
+++ b/src/main/kotlin/no/nav/klage/search/service/PersonSearchService.kt
@@ -2,7 +2,7 @@ package no.nav.klage.search.service
 
 import no.nav.klage.search.clients.pdl.graphql.PdlClient
 import no.nav.klage.search.clients.pdl.graphql.SoekPersonResponse
-import no.nav.klage.search.domain.KlagebehandlingerSearchCriteria
+import no.nav.klage.search.domain.OppgaverOmPersonSearchCriteria
 import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.search.domain.personsoek.Navn
 import no.nav.klage.search.domain.personsoek.Person
@@ -22,7 +22,7 @@ class PersonSearchService(
         private val secureLogger = getSecureLogger()
     }
 
-    fun fnrSearch(input: KlagebehandlingerSearchCriteria): PersonSearchResponse? {
+    fun fnrSearch(input: OppgaverOmPersonSearchCriteria): PersonSearchResponse? {
         val searchHitsInES = esSoek(input)
         logger.debug("fnrSearch: Got ${searchHitsInES.size} hits from ES")
         val listOfPersonSoekResponse = searchHitsInES.groupBy { it.sakenGjelderFnr }.map { (fnr, klagebehandlinger) ->
@@ -41,7 +41,7 @@ class PersonSearchService(
         } else if (listOfPersonSoekResponse.isEmpty()) {
             null
         } else {
-            secureLogger.error("More than one hit for fnr {}.", input.foedselsnr)
+            secureLogger.error("More than one hit for fnr {}.", input.fnr)
             throw RuntimeException("More than one hit for fnr.")
         }
     }
@@ -66,8 +66,8 @@ class PersonSearchService(
         return people ?: emptyList()
     }
 
-    private fun esSoek(input: KlagebehandlingerSearchCriteria): List<EsKlagebehandling> {
-        val esResponse = elasticsearchService.findByCriteria(input)
+    private fun esSoek(input: OppgaverOmPersonSearchCriteria): List<EsKlagebehandling> {
+        val esResponse = elasticsearchService.findOppgaverOmPersonByCriteria(input)
         return esResponse.searchHits.map { it.content }
     }
 

--- a/src/main/kotlin/no/nav/klage/search/service/PersonSearchService.kt
+++ b/src/main/kotlin/no/nav/klage/search/service/PersonSearchService.kt
@@ -25,24 +25,18 @@ class PersonSearchService(
     fun fnrSearch(input: OppgaverOmPersonSearchCriteria): PersonSearchResponse? {
         val searchHitsInES = esSoek(input)
         logger.debug("fnrSearch: Got ${searchHitsInES.size} hits from ES")
-        val listOfPersonSoekResponse = searchHitsInES.groupBy { it.sakenGjelderFnr }.map { (fnr, klagebehandlinger) ->
-            PersonSearchResponse(
-                fnr = fnr!!,
-                fornavn = klagebehandlinger.first().sakenGjelderFornavn
-                    ?: throw RuntimeException("fornavn missing"),
-                mellomnavn = klagebehandlinger.first().sakenGjelderMellomnavn,
-                etternavn = klagebehandlinger.first().sakenGjelderEtternavn
-                    ?: throw RuntimeException("etternavn missing"),
-                klagebehandlinger = klagebehandlinger
-            )
-        }
-        return if (listOfPersonSoekResponse.size == 1) {
-            listOfPersonSoekResponse.first()
-        } else if (listOfPersonSoekResponse.isEmpty()) {
+        return if (searchHitsInES.isEmpty()) {
             null
         } else {
-            secureLogger.error("More than one hit for fnr {}.", input.fnr)
-            throw RuntimeException("More than one hit for fnr.")
+            PersonSearchResponse(
+                fnr = input.fnr,
+                fornavn = searchHitsInES.first().sakenGjelderFornavn
+                    ?: throw RuntimeException("fornavn missing"),
+                mellomnavn = searchHitsInES.first().sakenGjelderMellomnavn,
+                etternavn = searchHitsInES.first().sakenGjelderEtternavn
+                    ?: throw RuntimeException("etternavn missing"),
+                klagebehandlinger = searchHitsInES
+            )
         }
     }
 

--- a/src/test/kotlin/no/nav/klage/search/service/EktefelleElasticsearchServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/EktefelleElasticsearchServiceTest.kt
@@ -1,36 +1,22 @@
 package no.nav.klage.search.service
 
-import no.nav.klage.kodeverk.MedunderskriverFlyt
-import no.nav.klage.kodeverk.Tema
-import no.nav.klage.kodeverk.Type
-import no.nav.klage.kodeverk.Ytelse
 import no.nav.klage.search.config.ElasticsearchServiceConfiguration
-import no.nav.klage.search.domain.ExtraPersonWithYtelser
-import no.nav.klage.search.domain.KlagebehandlingerSearchCriteria
-import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling
-import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling.Status.IKKE_TILDELT
-import no.nav.klage.search.repositories.EsKlagebehandlingRepository
-import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Order
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
-import org.opensearch.index.query.QueryBuilders
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import java.time.LocalDate
-import java.time.LocalDateTime
 
 
 @ActiveProfiles("local")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 @Testcontainers
 @SpringBootTest(classes = [ElasticsearchServiceConfiguration::class])
+@Disabled
 class EktefelleElasticsearchServiceTest {
 
+    /*
     companion object {
         @Container
         @JvmField
@@ -252,4 +238,6 @@ class EktefelleElasticsearchServiceTest {
         assertThat(klagebehandlinger.size).isEqualTo(2L)
         assertThat(klagebehandlinger.map { it.id }).containsExactlyInAnyOrder("1002L", "1003L")
     }
+
+     */
 }

--- a/src/test/kotlin/no/nav/klage/search/service/ElasticsearchServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/ElasticsearchServiceTest.kt
@@ -5,7 +5,9 @@ import no.nav.klage.kodeverk.Tema
 import no.nav.klage.kodeverk.Type
 import no.nav.klage.kodeverk.Ytelse
 import no.nav.klage.search.config.ElasticsearchServiceConfiguration
-import no.nav.klage.search.domain.KlagebehandlingerSearchCriteria
+import no.nav.klage.search.domain.CountLedigeOppgaverMedUtgaattFristSearchCriteria
+import no.nav.klage.search.domain.LedigeOppgaverSearchCriteria
+import no.nav.klage.search.domain.SortField
 import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling.Status.IKKE_TILDELT
 import no.nav.klage.search.repositories.EsKlagebehandlingRepository
@@ -109,11 +111,15 @@ class ElasticsearchServiceTest {
     @Order(4)
     fun `Klagebehandling can be searched for by ytelse`() {
         val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+            service.findLedigeOppgaverByCriteria(
+                LedigeOppgaverSearchCriteria(
                     ytelser = listOf(Ytelse.OMS_OMP),
+                    typer = emptyList(),
+                    hjemler = emptyList(),
                     offset = 0,
                     limit = 10,
+                    order = no.nav.klage.search.domain.Order.ASC,
+                    sortField = SortField.FRIST,
                     kanBehandleEgenAnsatt = false,
                     kanBehandleFortrolig = false,
                     kanBehandleStrengtFortrolig = false,
@@ -126,19 +132,20 @@ class ElasticsearchServiceTest {
     @Test
     @Order(5)
     fun `Klagebehandling can be searched for by frist`() {
-        val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+        val antall =
+            service.countLedigeOppgaverMedUtgaatFristByCriteria(
+                CountLedigeOppgaverMedUtgaattFristSearchCriteria(
+                    typer = emptyList(),
+                    ytelser = emptyList(),
+                    hjemler = emptyList(),
                     fristFom = LocalDate.of(2020, 12, 1),
-                    offset = 0,
-                    limit = 10,
+                    fristTom = LocalDate.now(),
                     kanBehandleEgenAnsatt = false,
                     kanBehandleFortrolig = false,
                     kanBehandleStrengtFortrolig = false,
                 )
-            ).searchHits.map { it.content }
-        assertThat(klagebehandlinger.size).isEqualTo(1L)
-        assertThat(klagebehandlinger.first().id).isEqualTo("1001L")
+            )
+        assertThat(antall).isEqualTo(1L)
     }
 
 }

--- a/src/test/kotlin/no/nav/klage/search/service/FortroligElasticsearchServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/FortroligElasticsearchServiceTest.kt
@@ -5,7 +5,8 @@ import no.nav.klage.kodeverk.Tema
 import no.nav.klage.kodeverk.Type
 import no.nav.klage.kodeverk.Ytelse
 import no.nav.klage.search.config.ElasticsearchServiceConfiguration
-import no.nav.klage.search.domain.KlagebehandlingerSearchCriteria
+import no.nav.klage.search.domain.LedigeOppgaverSearchCriteria
+import no.nav.klage.search.domain.SortField
 import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling.Status.IKKE_TILDELT
 import no.nav.klage.search.repositories.EsKlagebehandlingRepository
@@ -213,11 +214,15 @@ class FortroligElasticsearchServiceTest {
     @Order(4)
     fun `Saksbehandler with no special rights will only see normal klagebehandlinger`() {
         val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+            service.findLedigeOppgaverByCriteria(
+                LedigeOppgaverSearchCriteria(
                     ytelser = listOf(Ytelse.OMS_OMP),
+                    typer = emptyList(),
+                    hjemler = emptyList(),
                     offset = 0,
                     limit = 10,
+                    order = no.nav.klage.search.domain.Order.ASC,
+                    sortField = SortField.FRIST,
                     kanBehandleEgenAnsatt = false,
                     kanBehandleFortrolig = false,
                     kanBehandleStrengtFortrolig = false,
@@ -230,11 +235,15 @@ class FortroligElasticsearchServiceTest {
     @Order(5)
     fun `Saksbehandler with egen ansatt rights will only see normal klagebehandlinger and those for egen ansatte, but not egen ansatte that are fortrolig or strengt fortrolig`() {
         val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+            service.findLedigeOppgaverByCriteria(
+                LedigeOppgaverSearchCriteria(
                     ytelser = listOf(Ytelse.OMS_OMP),
+                    typer = emptyList(),
+                    hjemler = emptyList(),
                     offset = 0,
                     limit = 10,
+                    order = no.nav.klage.search.domain.Order.ASC,
+                    sortField = SortField.FRIST,
                     kanBehandleEgenAnsatt = true,
                     kanBehandleFortrolig = false,
                     kanBehandleStrengtFortrolig = false,
@@ -247,11 +256,15 @@ class FortroligElasticsearchServiceTest {
     @Order(6)
     fun `Saksbehandler with fortrolig rights will see normale klagebehandlinger and fortrolige klagebehandlinger, including the combo fortrolig and egen ansatt`() {
         val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+            service.findLedigeOppgaverByCriteria(
+                LedigeOppgaverSearchCriteria(
                     ytelser = listOf(Ytelse.OMS_OMP),
+                    typer = emptyList(),
+                    hjemler = emptyList(),
                     offset = 0,
                     limit = 10,
+                    order = no.nav.klage.search.domain.Order.ASC,
+                    sortField = SortField.FRIST,
                     kanBehandleEgenAnsatt = false,
                     kanBehandleFortrolig = true,
                     kanBehandleStrengtFortrolig = false,
@@ -267,11 +280,15 @@ class FortroligElasticsearchServiceTest {
     @Order(7)
     fun `Saksbehandler with fortrolig rights and egen ansatt rights will see normale klagebehandling, fortrolige klagebehandlinger and egen ansatt klagebehandlinger`() {
         val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+            service.findLedigeOppgaverByCriteria(
+                LedigeOppgaverSearchCriteria(
                     ytelser = listOf(Ytelse.OMS_OMP),
+                    typer = emptyList(),
+                    hjemler = emptyList(),
                     offset = 0,
                     limit = 10,
+                    order = no.nav.klage.search.domain.Order.ASC,
+                    sortField = SortField.FRIST,
                     kanBehandleEgenAnsatt = true,
                     kanBehandleFortrolig = true,
                     kanBehandleStrengtFortrolig = false,
@@ -287,11 +304,15 @@ class FortroligElasticsearchServiceTest {
     @Order(8)
     fun `Saksbehandler with strengt fortrolig rights and egen ansatt rights will see strengt fortrolige klagebehandlinger, including the combo strengt fortrolig and egen ansatt`() {
         val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+            service.findLedigeOppgaverByCriteria(
+                LedigeOppgaverSearchCriteria(
                     ytelser = listOf(Ytelse.OMS_OMP),
+                    typer = emptyList(),
+                    hjemler = emptyList(),
                     offset = 0,
                     limit = 10,
+                    order = no.nav.klage.search.domain.Order.ASC,
+                    sortField = SortField.FRIST,
                     kanBehandleEgenAnsatt = true,
                     kanBehandleFortrolig = false,
                     kanBehandleStrengtFortrolig = true,
@@ -306,11 +327,15 @@ class FortroligElasticsearchServiceTest {
     @Order(9)
     fun `Saksbehandler with strengt fortrolig rights without egen ansatt rights will only see strengt fortrolige klagebehandlinger, including the combo strengt fortrolig and egen ansatt`() {
         val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+            service.findLedigeOppgaverByCriteria(
+                LedigeOppgaverSearchCriteria(
                     ytelser = listOf(Ytelse.OMS_OMP),
+                    typer = emptyList(),
+                    hjemler = emptyList(),
                     offset = 0,
                     limit = 10,
+                    order = no.nav.klage.search.domain.Order.ASC,
+                    sortField = SortField.FRIST,
                     kanBehandleEgenAnsatt = false,
                     kanBehandleFortrolig = false,
                     kanBehandleStrengtFortrolig = true,
@@ -326,11 +351,15 @@ class FortroligElasticsearchServiceTest {
     @Order(10)
     fun `Saksbehandler with fortrolig and strengt fortrolig rights will only see strengt fortrolige and fortrolige klagebehandlinger, including those that also are egen ansatte`() {
         val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+            service.findLedigeOppgaverByCriteria(
+                LedigeOppgaverSearchCriteria(
                     ytelser = listOf(Ytelse.OMS_OMP),
+                    typer = emptyList(),
+                    hjemler = emptyList(),
                     offset = 0,
                     limit = 10,
+                    order = no.nav.klage.search.domain.Order.ASC,
+                    sortField = SortField.FRIST,
                     kanBehandleEgenAnsatt = false,
                     kanBehandleFortrolig = true,
                     kanBehandleStrengtFortrolig = true,
@@ -348,11 +377,15 @@ class FortroligElasticsearchServiceTest {
     @Order(11)
     fun `Saksbehandler with fortrolig and strengt fortrolig and egen ansatt rights will only see strengt fortrolige and fortrolige klagebehandlinger, including those that also are egen ansatte`() {
         val klagebehandlinger: List<EsKlagebehandling> =
-            service.findByCriteria(
-                KlagebehandlingerSearchCriteria(
+            service.findLedigeOppgaverByCriteria(
+                LedigeOppgaverSearchCriteria(
                     ytelser = listOf(Ytelse.OMS_OMP),
+                    typer = emptyList(),
+                    hjemler = emptyList(),
                     offset = 0,
                     limit = 10,
+                    order = no.nav.klage.search.domain.Order.ASC,
+                    sortField = SortField.FRIST,
                     kanBehandleEgenAnsatt = true,
                     kanBehandleFortrolig = true,
                     kanBehandleStrengtFortrolig = true,

--- a/src/test/kotlin/no/nav/klage/search/service/RelatedKlagebehandlingerTest.kt
+++ b/src/test/kotlin/no/nav/klage/search/service/RelatedKlagebehandlingerTest.kt
@@ -1,37 +1,21 @@
 package no.nav.klage.search.service
 
-import no.nav.klage.kodeverk.MedunderskriverFlyt
-import no.nav.klage.kodeverk.Tema
-import no.nav.klage.kodeverk.Type
-import no.nav.klage.kodeverk.Ytelse
 import no.nav.klage.search.config.ElasticsearchServiceConfiguration
-import no.nav.klage.search.domain.KlagebehandlingerSearchCriteria
-import no.nav.klage.search.domain.Statuskategori
-import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling
-import no.nav.klage.search.domain.elasticsearch.EsKlagebehandling.Status.UKJENT
-import no.nav.klage.search.repositories.EsKlagebehandlingRepository
-import no.nav.klage.search.repositories.SearchHits
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.SoftAssertions
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Order
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
-import org.opensearch.index.query.QueryBuilders
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import java.time.LocalDate
-import java.time.LocalDateTime
 
 
 @ActiveProfiles("local")
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 @Testcontainers
 @SpringBootTest(classes = [ElasticsearchServiceConfiguration::class])
+@Disabled
 class RelatedKlagebehandlingerTest {
+    /*
 
     companion object {
         @Container
@@ -143,5 +127,7 @@ class RelatedKlagebehandlingerTest {
         val results = service.findByCriteria(searchCriteria)
         assertThat(results.searchHits).hasSize(3)
     }
+
+     */
 
 }


### PR DESCRIPTION
Jeg har fjernet KlagebehandlingerSearchCriteria og de generelle metodene som brukte denne. Alt er nå mer spisset.
Men jeg har ikke slettet alt, jeg har bare kommentert ut en del av det. Grunnen til det er denne getRelaterteKlagebehandlinger-metoden i KlagebehandlingSearchController, som også er kommentert ut. Hvis den skal inn igjen, så må vi lage kode som håndterer det, og da kan det være greit å ha noe av det gamle å kikke på..?